### PR TITLE
Compatibility with Way Better Romance

### DIFF
--- a/1.4/Patches/Patches_Traits.xml
+++ b/1.4/Patches/Patches_Traits.xml
@@ -515,17 +515,33 @@
     <success>Always</success>
     <xpath>*/TraitDef[defName = "Polyamorous"]/commonality</xpath>
     <match Class="PatchOperationReplace">
-      <xpath>*/TraitDef[defName = "Polyamorous" or defName = "Straight"]/commonality</xpath>
+      <xpath>*/TraitDef[defName = "Polyamorous"]/commonality</xpath>
       <value>
         <commonality>0</commonality>
       </value>
     </match>
     <nomatch Class="PatchOperationAdd">
-      <xpath>*/TraitDef[defName = "Polyamorous" or defName = "Straight"]</xpath>
+      <xpath>*/TraitDef[defName = "Polyamorous"]</xpath>
       <value>
         <commonality>0</commonality>
       </value>
     </nomatch>
+  </Operation>
+  <Operation Class="PatchOperationConditional">
+    <success>Always</success>
+    <xpath>*/TraitDef[defName = "Straight"]/commonality</xpath>
+    <match Class="PatchOperationReplace">
+      <xpath>*/TraitDef[defName = "Straight"]/commonality</xpath>
+      <value>
+        <commonality>0</commonality>
+      </value>
+	</match>
+	<nomatch Class="PatchOperationAdd">
+      <xpath>*/TraitDef[defName = "Straight"]</xpath>
+      <value>
+        <commonality>0</commonality>
+	  </value>
+	</nomatch>
   </Operation>
   <!--<Operation Class="PatchOperationConditional">
   <success>Always</success>

--- a/Source/SyrTraits/HarmonyPatches/CompAbilityEffect_WordOfLove_Valid.cs
+++ b/Source/SyrTraits/HarmonyPatches/CompAbilityEffect_WordOfLove_Valid.cs
@@ -10,6 +10,10 @@ public static class CompAbilityEffect_WordOfLove_Valid
     public static bool Prefix(ref bool __result, LocalTargetInfo target,
         bool throwMessages)
     {
+        if (SyrIndividuality.RomanceDisabled)
+        {
+            return true;
+        }
         var pawn = target.Pawn;
         var compIndividuality = pawn.TryGetComp<CompIndividuality>();
         if (pawn != null)

--- a/Source/SyrTraits/HarmonyPatches/CompAbilityEffect_WordOfLove_ValidateTarget.cs
+++ b/Source/SyrTraits/HarmonyPatches/CompAbilityEffect_WordOfLove_ValidateTarget.cs
@@ -10,6 +10,10 @@ public static class CompAbilityEffect_WordOfLove_ValidateTarget
     public static bool Prefix(ref bool __result, LocalTargetInfo target,
         LocalTargetInfo ___selectedTarget)
     {
+        if (SyrIndividuality.RomanceDisabled)
+        {
+            return true;
+        }
         var pawn = ___selectedTarget.Pawn;
         var pawn2 = target.Pawn;
         var compIndividuality = pawn.TryGetComp<CompIndividuality>();

--- a/Source/SyrTraits/SyrIndividuality.cs
+++ b/Source/SyrTraits/SyrIndividuality.cs
@@ -12,7 +12,7 @@ public class SyrIndividuality : Mod
     private static bool forcedDisabled;
 
     public static bool RationalRomanceActive;
-
+    public static bool WayBetterRomanceActive;
     public static bool PsychologyActive;
 
     public SyrIndividuality(ModContentPack content)
@@ -20,7 +20,8 @@ public class SyrIndividuality : Mod
     {
         PsychologyActive = ModsConfig.ActiveModsInLoadOrder.Any(m => m.Name.Contains("Psychology"));
         RationalRomanceActive = ModsConfig.ActiveModsInLoadOrder.Any(m => m.Name.Contains("Rational Romance"));
-        forcedDisabled = PsychologyActive || RationalRomanceActive;
+        WayBetterRomanceActive = ModsConfig.IsActive("divineDerivative.Romance");
+        forcedDisabled = PsychologyActive || RationalRomanceActive || WayBetterRomanceActive;
         settings = GetSettings<SyrIndividualitySettings>();
         currentVersion = VersionFromManifest.GetVersionFromModMetaData(content.ModMetaData);
     }
@@ -42,7 +43,7 @@ public class SyrIndividuality : Mod
         listing_Standard.Label("SyrTraitsTraitCount".Translate());
         listing_Standard.IntRange(ref SyrIndividualitySettings.traitCount, 0, 8);
         listing_Standard.Gap(24f);
-        if (PsychologyActive || RationalRomanceActive)
+        if (PsychologyActive || RationalRomanceActive || WayBetterRomanceActive)
         {
             GUI.color = Color.red;
             var text = "";
@@ -50,7 +51,7 @@ public class SyrIndividuality : Mod
             {
                 text = "SyrTraitsDisabledPsychology".Translate();
             }
-            else if (RationalRomanceActive)
+            else if (RationalRomanceActive || WayBetterRomanceActive)
             {
                 text = "SyrTraitsDisabledRationalRomance".Translate();
             }


### PR DESCRIPTION
Some changes to make Individuality work better with Way Better Romance.

- Allow Way Better Romance to be recognized as a version of Rational Romance, automatically disabling romance changes.
- Add romance setting check to CompAbilityEffect_WordOfLove patches.
- Update 1.4 patches.

Assembly not included in case you need to make other changes.