### PR TITLE
Fix incompatibility with Dead Man's Switch (And other possible mechanoid mods)

### DIFF
--- a/Source/SyrTraits/HarmonyPatches/Pawn_SkillTracker_GetSkill.cs
+++ b/Source/SyrTraits/HarmonyPatches/Pawn_SkillTracker_GetSkill.cs
@@ -9,6 +9,11 @@ public static class Pawn_SkillTracker_GetSkill
 {
     public static void Postfix(ref SkillRecord __result, Pawn ___pawn)
     {
+        if (___pawn.story?.traits == null)
+        {
+            return;
+        }
+
         if (!___pawn.story.traits.HasTrait(SyrTraitDefOf.SYR_GreenThumb) || !WorkGiver_GrowerSow_JobOnCell.greenThumb)
         {
             return;


### PR DESCRIPTION
When Individuality and DMS is loaded together, clicking on the info of a DMS mechanoid spams error.
This is ultimately due to NRE at SyrTraits.Pawn_SkillTracker_GetSkill.Postfix because apparently, DMS mechanoids have skills, but their traits are null
Any other mod that has pawns with such setup will have the same issue.

I found that StatWorker_GetExplanationUnfinalized patch in this mod also checks for pawn?.story?.traits == null, so doing null check on GetSkill not only seems appropriate for the mod in itself, but also will prevent conflict with mods like DMS.

Changes: Add __pawn.story?.traits==null check for skill_tracker_getskill patch