### PR TITLE
Fixed Slow Learner and Creative Thinker

### DIFF
--- a/1.1/Patches/Patches_Traits.xml
+++ b/1.1/Patches/Patches_Traits.xml
@@ -396,7 +396,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>*/TraitDef[defName = "SlowLearner"]/degreeDatas/li/statOffsets/GlobalLearningFactor</xpath>
     <value>
-      <GlobalLearningFactor>-1.3</GlobalLearningFactor>
+      <GlobalLearningFactor>-0.5</GlobalLearningFactor>
     </value>
   </Operation>
   <Operation Class="PatchOperationReplace">

--- a/1.2/Patches/Patches_Traits.xml
+++ b/1.2/Patches/Patches_Traits.xml
@@ -396,7 +396,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>*/TraitDef[defName = "SlowLearner"]/degreeDatas/li/statOffsets/GlobalLearningFactor</xpath>
     <value>
-      <GlobalLearningFactor>-1.3</GlobalLearningFactor>
+      <GlobalLearningFactor>-0.5</GlobalLearningFactor>
     </value>
   </Operation>
   <Operation Class="PatchOperationReplace">

--- a/1.3/Patches/Patches_Traits.xml
+++ b/1.3/Patches/Patches_Traits.xml
@@ -396,7 +396,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>*/TraitDef[defName = "SlowLearner"]/degreeDatas/li/statOffsets/GlobalLearningFactor</xpath>
     <value>
-      <GlobalLearningFactor>-1.3</GlobalLearningFactor>
+      <GlobalLearningFactor>-0.5</GlobalLearningFactor>
     </value>
   </Operation>
   <Operation Class="PatchOperationReplace">

--- a/1.4/Patches/Patches_Traits.xml
+++ b/1.4/Patches/Patches_Traits.xml
@@ -396,7 +396,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>*/TraitDef[defName = "SlowLearner"]/degreeDatas/li/statOffsets/GlobalLearningFactor</xpath>
     <value>
-      <GlobalLearningFactor>-1.3</GlobalLearningFactor>
+      <GlobalLearningFactor>-0.5</GlobalLearningFactor>
     </value>
   </Operation>
   <Operation Class="PatchOperationReplace">

--- a/1.5/Patches/Patches_Traits.xml
+++ b/1.5/Patches/Patches_Traits.xml
@@ -396,7 +396,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>*/TraitDef[defName = "SlowLearner"]/degreeDatas/li/statOffsets/GlobalLearningFactor</xpath>
     <value>
-      <GlobalLearningFactor>-1.3</GlobalLearningFactor>
+      <GlobalLearningFactor>-0.5</GlobalLearningFactor>
     </value>
   </Operation>
   <Operation Class="PatchOperationReplace">

--- a/Languages/ChineseSimplified/Keyed/settings.xml
+++ b/Languages/ChineseSimplified/Keyed/settings.xml
@@ -29,8 +29,6 @@
   <SyrIndividuality_EditModeOff>禁用编辑模式</SyrIndividuality_EditModeOff>
   <SyrIndividuality_EditModeTooltip>左键单击字段可增加，右键单击可减少</SyrIndividuality_EditModeTooltip>
   <BodyWeightOffset>自然的体形</BodyWeightOffset>
-  <SyrTraitsDaVinciGene>达芬奇基因</SyrTraitsDaVinciGene>
-  <SyrTraitsSlowLearnerLabel>学习速度慢</SyrTraitsSlowLearnerLabel>
   <SyrTraitsSlowLearner>总技能奖励</SyrTraitsSlowLearner>
   <SyrTraitsCurrentModVersion>已安装模块版本：{0}</SyrTraitsCurrentModVersion>
 </LanguageData>

--- a/Languages/English/Keyed/settings.xml
+++ b/Languages/English/Keyed/settings.xml
@@ -28,8 +28,6 @@
   <SyrIndividuality_EditModeOff>Disable edit mode</SyrIndividuality_EditModeOff>
   <SyrIndividuality_EditModeTooltip>Left-click a field to increase, right-click to decrease</SyrIndividuality_EditModeTooltip>
   <BodyWeightOffset>Natural body shape</BodyWeightOffset>
-  <SyrTraitsDaVinciGene>Da Vinci Gene</SyrTraitsDaVinciGene>
-  <SyrTraitsSlowLearnerLabel>Slow learner</SyrTraitsSlowLearnerLabel>
-  <SyrTraitsSlowLearner>Bonus from total skills</SyrTraitsSlowLearner>
+  <SyrTraitsSlowLearner>Total skills</SyrTraitsSlowLearner>
   <SyrTraitsCurrentModVersion>Installed mod-version: {0}</SyrTraitsCurrentModVersion>
 </LanguageData>

--- a/Languages/French/Keyed/settings.xml
+++ b/Languages/French/Keyed/settings.xml
@@ -29,8 +29,6 @@
   <SyrIndividuality_EditModeOff>Désactiver le mode édition</SyrIndividuality_EditModeOff>
   <SyrIndividuality_EditModeTooltip>Cliquez avec le bouton gauche de la souris sur un champ pour l'augmenter, cliquez avec le bouton droit de la souris pour le diminuer.</SyrIndividuality_EditModeTooltip>
   <BodyWeightOffset>Forme naturelle du corps</BodyWeightOffset>
-  <SyrTraitsDaVinciGene>Le gène de Vinci</SyrTraitsDaVinciGene>
-  <SyrTraitsSlowLearnerLabel>Apprentissage lent</SyrTraitsSlowLearnerLabel>
   <SyrTraitsSlowLearner>Bonus de compétences totales</SyrTraitsSlowLearner>
   <SyrTraitsCurrentModVersion>Version installée du mod : {0}</SyrTraitsCurrentModVersion>
 </LanguageData>

--- a/Languages/German/Keyed/settings.xml
+++ b/Languages/German/Keyed/settings.xml
@@ -29,8 +29,6 @@
   <SyrIndividuality_EditModeOff>Bearbeitungsmodus deaktivieren</SyrIndividuality_EditModeOff>
   <SyrIndividuality_EditModeTooltip>Klicken Sie mit der linken Maustaste auf ein Feld, um es zu vergrößern, mit der rechten Maustaste, um es zu verkleinern.</SyrIndividuality_EditModeTooltip>
   <BodyWeightOffset>Natürliche Körperform</BodyWeightOffset>
-  <SyrTraitsDaVinciGene>Da Vinci-Gen</SyrTraitsDaVinciGene>
-  <SyrTraitsSlowLearnerLabel>Langsam Lernende</SyrTraitsSlowLearnerLabel>
   <SyrTraitsSlowLearner>Bonus aus den Gesamtfertigkeiten</SyrTraitsSlowLearner>
   <SyrTraitsCurrentModVersion>Installierte Mod-Version: {0}</SyrTraitsCurrentModVersion>
 </LanguageData>

--- a/Source/SyrTraits/ComplementBranchOpcodeExtension.cs
+++ b/Source/SyrTraits/ComplementBranchOpcodeExtension.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Verse;
+
+namespace SyrTraits
+{
+    internal static class ComplementBranchOpcodeExtension
+    {
+        private readonly struct ComplementOpCodeInfo(string name, bool standalone = false, string requiredNewPart = null, string requiredRemovePart = null)
+        {
+            public readonly string name = name;
+            public readonly bool standalone = standalone && requiredNewPart is null && requiredRemovePart is null;
+            public readonly string requiredNewPart = requiredNewPart;
+            public readonly string requiredRemovePart = requiredRemovePart;
+        }
+
+        private static readonly Dictionary<string, ComplementOpCodeInfo> _complementOpCodes = new()
+        {
+            ["Br"] = new("Nop", standalone: true),
+            ["Brfalse"] = new("Brtrue"),
+            ["Brtrue"] = new("Brfalse"),
+            ["Beq"] = new("Bne", requiredNewPart: "Un"),
+            ["Bne"] = new("Beq", requiredRemovePart: "Un"),
+            ["Blt"] = new("Bge"),
+            ["Bge"] = new("Blt"),
+            ["Bgt"] = new("Ble"),
+            ["Ble"] = new("Bgt"),
+        };
+        
+        public static OpCode Complement(this OpCode opCode)
+        {
+            string[] splitOpCodeName = CaptalizeFirstSplit(opCode.Name, '.');
+            string mainPart = splitOpCodeName[0];
+            ComplementOpCodeInfo complement = _complementOpCodes.GetValueOrDefault(mainPart);
+
+            if (complement.standalone)
+                splitOpCodeName = [complement.name];
+            else
+                splitOpCodeName[0] = complement.name;
+
+            if (complement.requiredNewPart is not null && !splitOpCodeName.Contains(complement.requiredNewPart))
+            {
+                string[] newSplitOpCodeName = new string[splitOpCodeName.Length + 1];
+                newSplitOpCodeName[0] = splitOpCodeName[0];
+                newSplitOpCodeName[1] = complement.requiredNewPart;
+
+                for (int i = 1; i < splitOpCodeName.Length; i++)
+                    newSplitOpCodeName[i + 1] = splitOpCodeName[i];
+
+                splitOpCodeName = newSplitOpCodeName;
+            }
+            if (complement.requiredRemovePart is not null && splitOpCodeName.Contains(complement.requiredRemovePart))
+            {
+                string[] newSplitOpCodeName = new string[splitOpCodeName.Length - 1];
+
+                int index;
+                for (index = 0; splitOpCodeName[index] != complement.requiredRemovePart; index++)
+                    newSplitOpCodeName[index] = splitOpCodeName[index];
+
+                int indexOfBadPart = index;
+                for (index = indexOfBadPart + 1; index < splitOpCodeName.Length; index++)
+                    newSplitOpCodeName[index - 1] = splitOpCodeName[index];
+
+                splitOpCodeName = newSplitOpCodeName;
+            }
+
+            string complementOpCodeName = string.Join("_", splitOpCodeName);
+            FieldInfo complementOpCodeField = typeof(OpCodes).GetField(complementOpCodeName);
+
+            if (complementOpCodeField is null)
+                throw new ArgumentException($"Could not find complement of {opCode.Name}.", nameof(opCode));
+            return (OpCode)complementOpCodeField.GetValue(null);
+        }
+
+        private static string[] CaptalizeFirstSplit(string str, char separator)
+        {
+            string[] split = str.Split(separator);
+            for (int i = 0; i < split.Length; i++)
+                split[i] = split[i].CapitalizeFirst();
+
+            return split;
+        }
+    }
+}

--- a/Source/SyrTraits/HarmonyPatches/StatWorker_GetExplanationUnfinalized.cs
+++ b/Source/SyrTraits/HarmonyPatches/StatWorker_GetExplanationUnfinalized.cs
@@ -1,61 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Text;
 using HarmonyLib;
 using RimWorld;
-using UnityEngine;
 using Verse;
 
 namespace SyrTraits;
 
+using static StatWorker_GetValueUnfinalized.StatBonuses;
+
 [HarmonyPatch(typeof(StatWorker), nameof(StatWorker.GetExplanationUnfinalized))]
 public static class StatWorker_GetExplanationUnfinalized
 {
-    public static void Postfix(ref string __result, StatWorker __instance, StatRequest req,
-        StatDef ___stat)
+    private static readonly FieldInfo _storyField = typeof(Pawn).GetField(nameof(Pawn.story));
+    private static readonly FieldInfo _traitsField = typeof(Pawn_StoryTracker).GetField(nameof(Pawn_StoryTracker.traits));
+    private static readonly FieldInfo _creativeThinkerField = typeof(SyrTraitDefOf).GetField(nameof(SyrTraitDefOf.SYR_CreativeThinker));
+    private static readonly MethodInfo _hasTraitMethod = typeof(TraitSet).GetMethod(nameof(TraitSet.HasTrait), [typeof(TraitDef)]);
+    private static readonly MethodInfo _countGetter = typeof(List<Trait>).PropertyGetter(nameof(List<Trait>.Count));
+    private static readonly FieldInfo _statField = typeof(StatWorker).Field("stat");
+    private static readonly MethodInfo _addCustomTraitsExplanationsMethod = typeof(StatWorker_GetExplanationUnfinalized).Method(nameof(AddCustomTraitsExplanations));
+
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
-        var pawn = req.Thing as Pawn;
-        if (pawn?.story?.traits == null || ___stat == null)
+        CodeMatcher codeMatcher = new CodeMatcher(instructions);
+
+        // Finding the required variables
+        Func<CodeInstruction, bool> stringBuilderPredicate = instruction =>
         {
+            if (instruction.opcode != OpCodes.Newobj)
+                return false;
+
+            ConstructorInfo constructor = (ConstructorInfo)instruction.operand;
+            return typeof(StringBuilder).IsAssignableFrom(constructor.DeclaringType);
+        };
+        CodeMatch stringBuilderMatch = new CodeMatch(stringBuilderPredicate);
+        codeMatcher.MatchStartForward(stringBuilderMatch);
+        codeMatcher.MatchStartForward(CodeMatch.StoresLocal());
+        codeMatcher.ThrowIfInvalid($"{SyrIndividuality.logPrefix} Could not find StringBuilder variable in StatWorker.GetExplanationUnfinalized");
+        int stringBuilderLocalIndex = codeMatcher.Instruction.LocalIndex();
+        
+        CodeMatch pawnMatch = new CodeMatch(OpCodes.Isinst, typeof(Pawn));
+        codeMatcher.MatchStartForward(pawnMatch);
+        codeMatcher.MatchStartForward(CodeMatch.StoresLocal());
+        codeMatcher.ThrowIfInvalid($"{SyrIndividuality.logPrefix} Could not find Pawn variable in StatWorker.GetExplanationUnfinalized");
+        int pawnLocalIndex = codeMatcher.Instruction.LocalIndex();
+
+        // Entering the relevant section
+        codeMatcher.MatchStartForward(CodeMatch.LoadsField(_traitsField));
+        codeMatcher.ThrowIfInvalid($"{SyrIndividuality.logPrefix} Could not find load field instruction for Pawn_StoryTracker.traits in StatWorker.GetExplanationUnfinalized");
+
+        codeMatcher.MatchStartForward(CodeMatch.LoadsConstant("StatsReport_RelevantTraits"));
+        codeMatcher.MatchStartBackwards(new CodeMatch(instruction => instruction.labels?.Count > 0));
+        codeMatcher.ThrowIfInvalid($"{SyrIndividuality.logPrefix} Could not find jump location for relevant traits explanations in StatWorker.GetExplanationUnfinalized");
+        List<Label> labels = codeMatcher.Instruction.labels;
+
+        /* 
+         * We need to change the condition for the trait offsets and factors code
+         * to be run, because Creative Thinker would not make the code run since
+         * the offsets it gives are all custom code and don't use the normal system
+         * at all
+        */
+        codeMatcher.MatchStartBackwards(new CodeMatch(instruction =>
+            instruction.operand is Label label && labels.Contains(label)));
+        codeMatcher.ThrowIfInvalid($"{SyrIndividuality.logPrefix} Could not find branch to relevant traits explanations in StatWorker.GetExplanationUnfinalized");
+        Label relevantTraitsLabel = (Label)codeMatcher.Instruction.operand;
+
+        codeMatcher.MatchStartForward(new CodeMatch(instruction =>
+            instruction.operand is Label label && !labels.Contains(label)));
+        codeMatcher.ThrowIfInvalid($"{SyrIndividuality.logPrefix} Could not find branch that avoids relevant traits explanations in StatWorker.GetExplanationUnfinalized");
+        Label noRelevantTraitsLabel = (Label)codeMatcher.Instruction.operand;
+        codeMatcher.Opcode = codeMatcher.Opcode.Complement();
+        codeMatcher.Operand = relevantTraitsLabel;
+
+        codeMatcher.Advance(1);
+        List<CodeInstruction> newConditionInstructions =
+        [
+            new CodeInstruction(OpCodes.Ldloc_S, pawnLocalIndex),
+            new CodeInstruction(OpCodes.Ldfld, _storyField),
+            new CodeInstruction(OpCodes.Ldfld, _traitsField),
+            new CodeInstruction(OpCodes.Ldsfld, _creativeThinkerField),
+            new CodeInstruction(OpCodes.Callvirt, _hasTraitMethod),
+            new CodeInstruction(OpCodes.Brfalse, noRelevantTraitsLabel)
+        ];
+        codeMatcher.InsertAndAdvance(newConditionInstructions);
+
+        // Adding the new explanations
+        codeMatcher.MatchStartForward(new CodeMatch() { opcodeSet = [OpCodes.Br, OpCodes.Br_S] });
+        codeMatcher.ThrowIfInvalid($"{SyrIndividuality.logPrefix} Could not find start branch to trait offsets loop.");
+        Label traitOffsetsConditionLabel = (Label)codeMatcher.Instruction.operand;
+
+        CodeMatch tocLabelMatch = new CodeMatch(ci => ci.labels.Contains(traitOffsetsConditionLabel));
+        codeMatcher.MatchStartForward(tocLabelMatch);
+        codeMatcher.ThrowIfInvalid($"{SyrIndividuality.logPrefix} Could not find start of trait offsets loop condition.");
+
+        codeMatcher.MatchStartForward(CodeMatch.Branches());
+        codeMatcher.ThrowIfInvalid($"{SyrIndividuality.logPrefix} Could not branch to trait offsets loop body.");
+        codeMatcher.Advance(1); // we are right after the trait offsets loop now
+
+        List<CodeInstruction> newInstructions = new List<CodeInstruction>()
+        {
+            new CodeInstruction(OpCodes.Ldarg_0),
+            new CodeInstruction(OpCodes.Dup),
+            new CodeInstruction(OpCodes.Ldfld, _statField),
+            new CodeInstruction(OpCodes.Ldarg_1),
+            new CodeInstruction(OpCodes.Ldloc_S, stringBuilderLocalIndex),
+            new CodeInstruction(OpCodes.Call, _addCustomTraitsExplanationsMethod)
+        };
+        codeMatcher.Insert(newInstructions);
+
+        return codeMatcher.InstructionEnumeration();
+    }
+
+    private static void AddCustomTraitsExplanations(StatWorker instance, StatDef stat, StatRequest req, StringBuilder stringBuilder)
+    {
+        Pawn pawn = req.Thing as Pawn;
+        if (pawn.skills?.skills is null || pawn.def.statBases is null)
             return;
-        }
 
-        float num;
-        float val;
-        StringBuilder stringBuilder;
-        if (___stat == StatDefOf.ResearchSpeed && pawn.story.traits.HasTrait(SyrTraitDefOf.SYR_CreativeThinker) &&
-            pawn.skills != null && pawn.def.statBases != null)
+        TraitSet pawnTraits = pawn.story.traits;
+        if (stat == StatDefOf.GlobalLearningFactor && pawnTraits.HasTrait(SyrTraitDefOf.SlowLearner))
         {
-            num = 1f;
-            if (pawn.def.statBases.Find(x => x?.stat != null && x.stat == ___stat) != null)
-            {
-                num = pawn.def.statBases.Find(x => x?.stat != null && x.stat == ___stat).value;
-            }
-
-            val = 0.115f * pawn.skills.GetSkill(SkillDefOf.Artistic).Level * num;
-            stringBuilder = new StringBuilder();
-            stringBuilder.AppendLine("SyrTraitsDaVinciGene".Translate());
-            stringBuilder.AppendLine(
-                $"{"    " + SkillDefOf.Artistic.LabelCap + " ("}{pawn.skills.GetSkill(SkillDefOf.Artistic).Level}): {val.ToStringSign()}{__instance.ValueToString(val, false)}");
-            __result += stringBuilder.ToString();
-            return;
+            Trait slowLearner = pawnTraits.GetTrait(SyrTraitDefOf.SlowLearner);
+            int totalSkillLevel = TotalSkillLevel(pawn);
+            float slowLearnerTotalOffset = slowLearner.OffsetOfStat(stat)
+                                         + SlowLearnerBonus(totalSkillLevel);
+            int insertionIndex = RemoveSlowLearnerStatDisplay(stringBuilder, slowLearner);
+            
+            stringBuilder.Insert(insertionIndex, $" ({"SyrTraitsSlowLearner".Translate()}: {totalSkillLevel}): {slowLearnerTotalOffset.ToStringSign()}{instance.ValueToString(slowLearnerTotalOffset, false)}");
         }
-
-        if (___stat != StatDefOf.GlobalLearningFactor || !pawn.story.traits.HasTrait(SyrTraitDefOf.SlowLearner) ||
-            pawn.skills == null || pawn.def.statBases == null)
+        else if (stat == StatDefOf.ResearchSpeed && pawnTraits.HasTrait(SyrTraitDefOf.SYR_CreativeThinker))
         {
-            return;
-        }
+            Trait creativeThinker = pawnTraits.GetTrait(SyrTraitDefOf.SYR_CreativeThinker);
+            float creativeThinkerBonus = CreativeThinkerBonus(pawn);
 
-        num = 0f;
-        foreach (var skill in pawn.skills.skills)
-        {
-            num += skill.levelInt;
+            stringBuilder.Append("    " + creativeThinker.LabelCap);
+            stringBuilder.AppendLine($" ({SkillDefOf.Artistic.LabelCap}: {pawn.skills.GetSkill(SkillDefOf.Artistic).Level}): {creativeThinkerBonus.ToStringSign()}{instance.ValueToString(creativeThinkerBonus, false)}");
         }
+    }
 
-        val = 0.02f * Mathf.Clamp(num, 40f, 140f);
-        stringBuilder = new StringBuilder();
-        stringBuilder.AppendLine("SyrTraitsSlowLearnerLabel".Translate());
-        stringBuilder.AppendLine(
-            $"{"    " + "SyrTraitsSlowLearner".Translate() + " ("}{num}): {val.ToStringSign()}{__instance.ValueToString(val, false)}");
-        __result += stringBuilder.ToString();
+    // removes the colon and everything after it (on the same line), and returns where the colon was
+    private static int RemoveSlowLearnerStatDisplay(StringBuilder stringBuilder, Trait slowLearnerTrait)
+    {
+        string stringBuilderString = stringBuilder.ToString();
+        string slowLearnerLabel = slowLearnerTrait.LabelCap;
+        int slowLearnerIndex = stringBuilderString.IndexOf(slowLearnerLabel);
+        
+        if (slowLearnerIndex < 0)
+            throw new ArgumentException($"Could not find {slowLearnerLabel} in {nameof(stringBuilder)}");
+
+        int statDisplayStart = slowLearnerIndex + slowLearnerLabel.Length;
+        int statDisplayEnd = stringBuilderString.IndexOf(Environment.NewLine, statDisplayStart);
+        stringBuilder.Remove(statDisplayStart, statDisplayEnd - statDisplayStart);
+
+        return statDisplayStart;
     }
 }

--- a/Source/SyrTraits/HarmonyPatches/StatWorker_GetValueUnfinalized.cs
+++ b/Source/SyrTraits/HarmonyPatches/StatWorker_GetValueUnfinalized.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
 using HarmonyLib;
 using RimWorld;
 using UnityEngine;
@@ -5,43 +8,113 @@ using Verse;
 
 namespace SyrTraits;
 
+using static StatWorker_GetValueUnfinalized.StatBonuses;
+
 [HarmonyPatch(typeof(StatWorker), nameof(StatWorker.GetValueUnfinalized))]
 public static class StatWorker_GetValueUnfinalized
 {
-    public static void Postfix(ref float __result, StatRequest req, StatDef ___stat)
+    public static class StatBonuses
     {
-        var pawn = req.Thing as Pawn;
-        if (pawn?.story?.traits == null || ___stat == null)
+        public const float baseSlowLearnerBonus = 0.02f;
+        public const int minSkillsBeforeSlowLearnerBonus = 40;
+        public const int maxSlowLearnerBonusMultiplier = 100;
+
+        public const float baseCreativeThinkerBonus = 0.115f;
+
+        internal static int TotalSkillLevel(Pawn pawn)
         {
+            int totalSkillLevel = 0;
+            foreach (SkillRecord skill in pawn.skills.skills)
+                totalSkillLevel += skill.levelInt;
+
+            return totalSkillLevel;
+        }
+
+        internal static float SlowLearnerBonus(int totalSkillLevel)
+        {
+            int bonusMultiplier = Mathf.Clamp(totalSkillLevel - minSkillsBeforeSlowLearnerBonus, 0, maxSlowLearnerBonusMultiplier);
+            return baseSlowLearnerBonus * bonusMultiplier;
+        }
+
+        public static float SlowLearnerBonus(Pawn pawn) => SlowLearnerBonus(TotalSkillLevel(pawn));
+
+        public static float CreativeThinkerBonus(Pawn pawn)
+        {
+            StatModifier researchSpeedStatBase = pawn.def.statBases.Find(x => x != null && x.stat == StatDefOf.ResearchSpeed);
+            float baseResearchSpeed = researchSpeedStatBase?.value ?? 1f;
+
+            return baseCreativeThinkerBonus * pawn.skills.GetSkill(SkillDefOf.Artistic).Level * baseResearchSpeed;
+        }
+    }
+
+    private static readonly MethodInfo _getBaseValueForMethod = typeof(StatWorker).GetMethod(nameof(StatWorker.GetBaseValueFor));
+    private static readonly FieldInfo _traitsField = typeof(Pawn_StoryTracker).GetField(nameof(Pawn_StoryTracker.traits));
+    private static readonly FieldInfo _hediffSetField = typeof(Pawn_HealthTracker).GetField(nameof(Pawn_HealthTracker.hediffSet));
+    private static readonly FieldInfo _statField = typeof(StatWorker).Field("stat");
+    private static readonly MethodInfo _applyCustomTraitOffsetsMethod = typeof(StatWorker_GetValueUnfinalized).Method(nameof(ApplyCustomTraitOffsets));
+
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        CodeMatcher codeMatcher = new CodeMatcher(instructions);
+
+        // Getting the stat value variable
+        codeMatcher.MatchStartForward(CodeMatch.Calls(_getBaseValueForMethod));
+        if (codeMatcher.IsInvalid)
+        {
+            Log.Error($"{SyrIndividuality.logPrefix} Could not find call instruction for StatWorker.GetBaseValueFor in StatWorker.GetValueUnfinalized.");
+            return instructions;
+        }
+
+        codeMatcher.MatchStartForward(CodeMatch.StoresLocal());
+        int statValueLocalIndes = codeMatcher.Instruction.LocalIndex();
+
+        // Finding the correct location for the new code
+        codeMatcher.MatchStartForward(CodeMatch.LoadsField(_traitsField));
+        if (codeMatcher.IsInvalid)
+        {
+            Log.Error($"{SyrIndividuality.logPrefix} Could not find load field instruction for Pawn_StoryTracker.traits in StatWorker.GetValueUnfinalized.");
+            return instructions;
+        }
+
+        codeMatcher.MatchStartForward(CodeMatch.LoadsField(_hediffSetField));
+        if (codeMatcher.IsInvalid)
+        {
+            Log.Error($"{SyrIndividuality.logPrefix} Could not find load field instruction for Pawn_HealthTracker.hediffSet in StatWorker.GetValueUnfinalized.");
+            return instructions;
+        }
+
+        codeMatcher.MatchStartBackwards(CodeMatch.Branches());
+        if (codeMatcher.IsInvalid)
+        {
+            Log.Error($"{SyrIndividuality.logPrefix} Could not find loop branch for applying trait offsets in StatWorker.GetValueUnfinalized.");
+            return instructions;
+        }
+        codeMatcher.Advance(1); // we are right after the trait offsets loop now
+
+        // New code to change the stat value
+        List<CodeInstruction> newInstructions = new List<CodeInstruction>()
+        {
+            new CodeInstruction(OpCodes.Ldarg_0),
+            new CodeInstruction(OpCodes.Ldfld, _statField),
+            new CodeInstruction(OpCodes.Ldarg_1),
+            new CodeInstruction(OpCodes.Ldloca, statValueLocalIndes),
+            new CodeInstruction(OpCodes.Call, _applyCustomTraitOffsetsMethod)
+        };
+        codeMatcher.Insert(newInstructions);
+
+        return codeMatcher.InstructionEnumeration();
+    }
+
+    private static void ApplyCustomTraitOffsets(StatDef stat, StatRequest req, ref float statValue)
+    {
+        Pawn pawn = req.Thing as Pawn;
+        if (pawn.skills?.skills is null || pawn.def.statBases is null)
             return;
-        }
 
-        float num;
-        if (pawn.story.traits.HasTrait(SyrTraitDefOf.SlowLearner) && ___stat == StatDefOf.GlobalLearningFactor &&
-            pawn.skills?.skills != null && pawn.def.statBases != null)
-        {
-            num = 0f;
-            foreach (var skill in pawn.skills.skills)
-            {
-                num += skill.levelInt;
-            }
-
-            __result += 0.02f * Mathf.Clamp(num, 40f, 140f);
-            return;
-        }
-
-        if (!pawn.story.traits.HasTrait(SyrTraitDefOf.SYR_CreativeThinker) || ___stat != StatDefOf.ResearchSpeed ||
-            pawn.skills == null || pawn.def.statBases == null)
-        {
-            return;
-        }
-
-        num = 1f;
-        if (pawn.def.statBases.Find(x => x?.stat != null && x.stat == ___stat) != null)
-        {
-            num = pawn.def.statBases.Find(x => x?.stat != null && x.stat == ___stat).value;
-        }
-
-        __result += 0.115f * pawn.skills.GetSkill(SkillDefOf.Artistic).Level * num;
+        TraitSet pawnTraits = pawn.story.traits;
+        if (stat == StatDefOf.GlobalLearningFactor && pawnTraits.HasTrait(SyrTraitDefOf.SlowLearner))
+            statValue += SlowLearnerBonus(pawn);
+        else if (stat == StatDefOf.ResearchSpeed && pawnTraits.HasTrait(SyrTraitDefOf.SYR_CreativeThinker))
+            statValue += CreativeThinkerBonus(pawn);
     }
 }

--- a/Source/SyrTraits/HarmonyPatches/Trait_TipString.cs
+++ b/Source/SyrTraits/HarmonyPatches/Trait_TipString.cs
@@ -1,40 +1,33 @@
-using System.Linq;
 using System.Text;
 using HarmonyLib;
 using RimWorld;
-using UnityEngine;
 using Verse;
 
 namespace SyrTraits;
+
+using static StatWorker_GetValueUnfinalized.StatBonuses;
 
 [HarmonyPatch(typeof(Trait), nameof(Trait.TipString))]
 public static class Trait_TipString
 {
     public static bool Prefix(ref string __result, Trait __instance, Pawn pawn)
     {
-        if (__instance?.def == null || __instance.def != SyrTraitDefOf.SlowLearner)
+        if (__instance?.def is null || __instance.def != SyrTraitDefOf.SlowLearner)
         {
             return true;
         }
 
-        var stringBuilder = new StringBuilder();
-        var currentData = __instance.CurrentData;
+        StringBuilder stringBuilder = new StringBuilder();
+        TraitDegreeData currentData = __instance.CurrentData;
         stringBuilder.Append(currentData.description.Formatted(pawn.Named("PAWN")).AdjustedFor(pawn).Resolve());
         if (pawn.skills != null && pawn.def.statBases != null)
         {
-            var num = 0f;
-            foreach (var skill in pawn.skills.skills)
-            {
-                num += skill.levelInt;
-            }
-
-            var f = (SyrTraitDefOf.SlowLearner.degreeDatas.First().statOffsets
-                         .Find(x => x?.stat != null && x.stat == StatDefOf.GlobalLearningFactor).value +
-                     (0.02f * Mathf.Clamp(num, 40f, 140f))) * 100f;
-            string value = "    " + StatDefOf.GlobalLearningFactor.LabelCap + " " + f.ToStringWithSign() + "%";
+            float slowLearnerTotalOffset = __instance.OffsetOfStat(StatDefOf.GlobalLearningFactor)
+                                         + SlowLearnerBonus(pawn);
+            
             stringBuilder.AppendLine();
             stringBuilder.AppendLine();
-            stringBuilder.AppendLine(value);
+            stringBuilder.AppendLine($"    {StatDefOf.GlobalLearningFactor.LabelCap} {slowLearnerTotalOffset.ToStringPercentSigned()}");
         }
 
         __result = stringBuilder.ToString();

--- a/Source/SyrTraits/SyrIndividuality.cs
+++ b/Source/SyrTraits/SyrIndividuality.cs
@@ -15,6 +15,8 @@ public class SyrIndividuality : Mod
     public static bool WayBetterRomanceActive;
     public static bool PsychologyActive;
 
+    public const string logPrefix = "[Individuality]:";
+
     public SyrIndividuality(ModContentPack content)
         : base(content)
     {


### PR DESCRIPTION
Hey, this is Choosechee. I talked to you about a bug with slow learner involving stat factors having the opposite effect of intended when a pawn had slow learner. It took a while due to some busyness, but I've just about finished the fix. In addition to slow learner, I've also updated creative thinker with a similar fix. Although it didn't have the issue slow learner had, fixing it too makes it act more consistently to other trait offsets. One thing that's very important is that I will need help porting the code to older versions, and I need translations for "Total skills". I also noticed that none of the def texts are translated. Why is that?

Commit Description:
Slow learner and creative thinker now apply their offsets before trait factors, improving consistency with other traits and fixing a major bug with slow learner.
Slow learner code was reworked to not require a -130% offset.
The stat explanations for slow learner and creative thinker now look different.
Removed some language strings that are now unnecessary.
Currently, the code fixes only affect the 1.5 version of the mod. The XML changes have been copied over to the other versions, but I need help or guidance on porting the code changes.

Here are pictures of the new looks for the stat explanations:
![slow learner 54 skill](https://github.com/user-attachments/assets/f69a8d5e-8944-4448-a529-46f1d3692260)
![creative thinker 6 artistic 8 intellectual](https://github.com/user-attachments/assets/c2759f42-38d1-4313-b4f4-0fc8e2ed12c9)

Here, you can see that the slow learner bug is fixed, as the slow study gene now lowers learning speed instead of raising it:
![slow learner 54 skill and slow study](https://github.com/user-attachments/assets/7e6ba4c5-b236-43d8-800d-6b8cc189253b)

Something to note: the changes to creative thinker have drastically changed its effect. It is now much less effective when pawns have low intellectual, and much more effective when pawns have high intellectual. Although this is more consistent with other stat offsets, it might be something that needs tweaking or reversion. Here are examples with the same artistic skill as the first creative thinker image, but less or more intellectual:
![creative thinker 6 artistic 2 intellectual](https://github.com/user-attachments/assets/9f344575-e403-4d7b-9fa8-478f19d6b481)
![creative thinker 6 artistic 16 intellectual](https://github.com/user-attachments/assets/12423572-0e5d-4483-8902-79bbb540f71e)
I will leave it up to you on what to do about this.